### PR TITLE
change: change alert background to gray opacity in

### DIFF
--- a/Tiny/Components/CustomAlertStop.swift
+++ b/Tiny/Components/CustomAlertStop.swift
@@ -82,7 +82,11 @@ struct CustomStopAlert: View {
             .padding()
             .background(
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color(.systemBackground))
+                    .fill(
+                        colorScheme == .dark ? Color(.gray).opacity(0.2) : Color(
+                            .systemBackground
+                        )
+                    )
                     .shadow(color: .black.opacity(0.1), radius: 20, x: 0, y: 10)
             )
             .padding(.horizontal, 60)


### PR DESCRIPTION
This pull request makes a minor UI improvement to the `CustomStopAlert` component. The background color now adapts based on the current color scheme, providing a more visually consistent experience in dark mode.

* UI enhancement:
  * In `Tiny/Components/CustomAlertStop.swift`, the background fill of the alert uses a semi-transparent gray in dark mode instead of the default system background color, improving appearance for users with dark mode enabled.